### PR TITLE
Conditionals, generalize blocks, support inline-blocks

### DIFF
--- a/Sources/PrismCore/TemplateParser/TemplateParser+Block.swift
+++ b/Sources/PrismCore/TemplateParser/TemplateParser+Block.swift
@@ -1,0 +1,119 @@
+//
+//  TemplateParser+Block.swift
+//  Prism
+//
+//  Created by Shai Mishali on 07/02/2020.
+//  Copyright © 2019 Gett. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Model
+extension TemplateParser {
+    /// A Template Block represents a nested condition or loop
+    /// and the information needed by the parser to process these
+    /// various blocks
+    ///
+    /// For example:
+    ///
+    ///     {{% FOR color %}}
+    ///     content
+    ///     {{% END color %}}
+    ///
+    /// Or:
+    ///
+    ///     {{% IF someToken %}}
+    ///     do something with the {{%someToken%}} value
+    ///     {{% ENDIF% }}
+    struct Block {
+        /// Body of the block, an array of the lines/content
+        /// the opening and closing tags of the block
+        let body: [String]
+        
+        /// The content prior to the body and block
+        /// - Note: Used when the block is inlined
+        let preBody: String?
+        
+        /// The content after the body and block
+        /// - Note: Used when the block is inlined
+        let postBody: String?
+        
+        /// The identifier following the block name
+        /// e.g. if writing {{% FOR color %}}, the identifierr
+        /// will be "color"
+        let identifier: String
+        
+        /// The index of the last line of the block
+        /// which is used by the parser to move on to the next
+        /// piece of content after the block is processed
+        let endLine: Int
+    }
+}
+
+// MARK: - Detection
+extension TemplateParser {
+    /// Attempt to detect a block identified by a keyword
+    /// and optional ending keyword in an array of lines,
+    /// starting from the provided current line index.
+    ///
+    /// - parameter keyword: A keyword for the block, for example: `FOR`
+    /// - parameter end: An optional ending for the block. If omitted, `END {identifier}` is used by default
+    /// - parameter lines: Array of lines being processed
+    /// - parameter currentLineIdx: The index of the current line to check against
+    ///
+    /// - returns: A processed `Block` information, or `nil` if a block can't be
+    ///            detected within the provided line
+    func detectBlock(keyword: String,
+                     end: String? = nil,
+                     lines: [String],
+                     currentLineIdx: Int) throws -> Block? {
+        let currentLine = lines[currentLineIdx]
+        let lineLength = currentLine.count
+
+        // Find occurences of block in the template
+        // Find matching END
+        let blockRegex = try NSRegularExpression(pattern: #"(^(.*))?\{\{%\ "# + keyword + #" (.*?) %\}\}((.*?)\{\{%\ "# + (end ?? "END \\2") + #" %\}\})?(.*?$)?"#)
+
+        // Detected the provided loop
+        guard let blockMatch = blockRegex.firstMatch(in: currentLine,
+                                                     options: .init(),
+                                                     range: NSRange(location: 0, length: lineLength)) else {
+            return nil
+        }
+        
+        let nsLine = currentLine as NSString
+        let preBodyRange = blockMatch.range(at: 1)
+        let preBody = preBodyRange.location == NSNotFound ? "" : nsLine.substring(with: preBodyRange)
+        let postBody = nsLine.substring(with: blockMatch.range(at: 6))
+        let indent = preBody.prefix(while: { $0 == " " })
+        
+        let identifier = nsLine.substring(with: blockMatch.range(at: 3))
+        
+        // If we have the fourth optional match, it means there's
+        // an in-line closing of the block instead of in a new-line
+        if blockMatch.range(at: 4).location != NSNotFound {
+            let body = nsLine.substring(with: blockMatch.range(at: 5))
+            return Block(body: [body],
+                         preBody: preBody,
+                         postBody: postBody,
+                         identifier: identifier,
+                         endLine: currentLineIdx)
+        }
+        
+        // Otherwise, we look for the next line that closes
+        // the opening loop, or throw an error otherwise
+        let endTerm = end ?? "END \(identifier)"
+        
+        guard let blockEnd = lines[currentLineIdx..<lines.count]
+                                .firstIndex(where: { $0 == "\(indent){{% \(endTerm) %}}" }) else {
+            throw Error.openLoop(identifier: identifier)
+        }
+        
+        let body = Array(lines[currentLineIdx + 1...blockEnd - 1])
+        return Block(body: body,
+                     preBody: nil,
+                     postBody: nil,
+                     identifier: identifier,
+                     endLine: blockEnd)
+    }
+}

--- a/Sources/PrismCore/TemplateParser/TemplateParser+Token.swift
+++ b/Sources/PrismCore/TemplateParser/TemplateParser+Token.swift
@@ -30,7 +30,10 @@ extension TemplateParser {
         case textStyleFontSize(Float)
         case textStyleIdentity(identity: Project.AssetIdentity,
                                style: Project.AssetIdentity.Style)
-
+        case textStyleAlignment(String?)
+        case textStyleLineHeight(Float?)
+        case textStyleLetterSpacing(Float?)
+        
         /// Parse a raw color token, such as "color.r", into its
         /// appropriate Token case (e.g. `.colorRed(value)` in this case).
         ///
@@ -103,6 +106,12 @@ extension TemplateParser {
                 }
 
                 self = try Token(rawColorToken: token, color: projectColor)
+            case "alignment":
+                self = .textStyleAlignment(textStyle.textAlign?.rawValue)
+            case "lineheight":
+                self = .textStyleLineHeight(textStyle.lineHeight)
+            case "letterspacing":
+                self = .textStyleLetterSpacing(textStyle.letterSpacing)
             default:
                 throw Error.unknownToken(token: rawTextStyleToken)
             }
@@ -114,8 +123,8 @@ extension TemplateParser {
         /// - parameter transformations: An array of Transofmration functions.
         ///
         /// - returns: A processed token value.
-        func stringValue(transformations: [Transformation]) -> String {
-            let baseString: String
+        func stringValue(transformations: [Transformation]) -> String? {
+            var baseString: String?
             switch self {
             case .colorAlpha(let a):
                 baseString = String(format: "%.2f", a)
@@ -133,9 +142,20 @@ extension TemplateParser {
                 baseString = name
             case .textStyleFontSize(let size):
                 baseString = "\(size)"
+            case .textStyleAlignment(let alignment):
+                baseString = alignment
+            case .textStyleLetterSpacing(let spacing):
+                if let spacing = spacing {
+                    baseString = "\(spacing)"
+                }
+            case .textStyleLineHeight(let height):
+                if let height = height {
+                    baseString = "\(height)"
+                }
             }
-
-            return transformations.reduce(into: baseString) { $0 = $1.apply(to: $0) }
+            
+            guard let output = baseString else { return nil }
+            return transformations.reduce(into: output) { $0 = $1.apply(to: $0) }
         }
     }
 }

--- a/Tests/Mocks/API/api.zeplin.dev_v1_projects_12345_text_styles.json
+++ b/Tests/Mocks/API/api.zeplin.dev_v1_projects_12345_text_styles.json
@@ -29,7 +29,8 @@
         "font_style":"normal",
         "line_height":24,
         "font_stretch":1,
-        "text_align":"left",
+        "text_align":"right",
+        "letter_spacing": 1.5,
         "color": {
           "r": 98,
           "b": 223,

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Color-Loop-should-provide-valid-output.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Color-Loop-should-provide-valid-output.txt
@@ -5,12 +5,12 @@ fake line 1
 fake line 2
 
 Some Structure {
-    Blue Sky, blueSky, blue_sky = 98, 182, 223, 1.00, #ff62b6df, #ff62b6df, #62b6df, #62b6df
-    Clear Reddish, clearReddish, clear_reddish = 223, 99, 105, 0.80, #ccdf6369, #ccdf6369, #df6369, #df6369
-    blue, blue, blue = 14, 40, 166, 1.00, #ff0e28a6, #ff0e28a6, #0e28a6, #0e28a6
-    green, green, green = 98, 166, 14, 1.00, #ff62a60e, #ff62a60e, #62a60e, #62a60e
-    mud, mud, mud = 166, 137, 14, 1.00, #ffa6890e, #ffa6890e, #a6890e, #a6890e
-    purple, purple, purple = 163, 14, 166, 1.00, #ffa30ea6, #ffa30ea6, #a30ea6, #a30ea6
-    red, red, red = 166, 14, 14, 1.00, #ffa60e0e, #ffa60e0e, #a60e0e, #a60e0e
-    teal, teal, teal = 14, 126, 166, 1.00, #ff0e7ea6, #ff0e7ea6, #0e7ea6, #0e7ea6
+    Blue Sky, blueSky, blue_sky = 98, 182, 223, 1.00, #ff62b6df, #ff62b6df, #62b6df, #62b6df, inline conditionally getting the ARGB value #ff62b6df, right?
+    Clear Reddish, clearReddish, clear_reddish = 223, 99, 105, 0.80, #ccdf6369, #ccdf6369, #df6369, #df6369, inline conditionally getting the ARGB value #ccdf6369, right?
+    blue, blue, blue = 14, 40, 166, 1.00, #ff0e28a6, #ff0e28a6, #0e28a6, #0e28a6, inline conditionally getting the ARGB value #ff0e28a6, right?
+    green, green, green = 98, 166, 14, 1.00, #ff62a60e, #ff62a60e, #62a60e, #62a60e, inline conditionally getting the ARGB value #ff62a60e, right?
+    mud, mud, mud = 166, 137, 14, 1.00, #ffa6890e, #ffa6890e, #a6890e, #a6890e, inline conditionally getting the ARGB value #ffa6890e, right?
+    purple, purple, purple = 163, 14, 166, 1.00, #ffa30ea6, #ffa30ea6, #a30ea6, #a30ea6, inline conditionally getting the ARGB value #ffa30ea6, right?
+    red, red, red = 166, 14, 14, 1.00, #ffa60e0e, #ffa60e0e, #a60e0e, #a60e0e, inline conditionally getting the ARGB value #ffa60e0e, right?
+    teal, teal, teal = 14, 126, 166, 1.00, #ff0e7ea6, #ff0e7ea6, #0e7ea6, #0e7ea6, inline conditionally getting the ARGB value #ff0e7ea6, right?
 }

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
@@ -5,10 +5,24 @@ fake line 1
 fake line 2
 
 Some Structure {
-    Base Heading, baseHeading, base_heading = LucidaGrande-Bold, 26.0, green,  green, green, #62a60e, #ff62a60e, 98, 166, 14, 1.00
-    Base Subhead, baseSubhead, base_subhead = LucidaGrande-Bold, 22.0, red,  red, red, #a60e0e, #ffa60e0e, 166, 14, 14, 1.00
-    Body, body, body = LucidaGrande, 14.0, blue,  blue, blue, #0e28a6, #ff0e28a6, 14, 40, 166, 1.00
-    Body 2, body2, body_2 = MyCustomFont-Regular, 14.0, Blue Sky,  blueSky, blue_sky, #62b6df, #ff62b6df, 98, 182, 223, 1.00
-    Highlight, highlight, highlight = AppleGothic, 18.0, purple,  purple, purple, #a30ea6, #ffa30ea6, 163, 14, 166, 1.00
-    Large Heading, largeHeading, large_heading = MyCustomFont-Light, 32.0, Clear Reddish,  clearReddish, clear_reddish, #df6369, #ccdf6369, 223, 99, 105, 0.80
+    Base Heading, baseHeading, base_heading = LucidaGrande-Bold, 26.0, green, green, green, #62a60e, #ff62a60e, 98, 166, 14, 1.00
+        We can also access optional stuff without an IF, which will result in an empty string like so: 
+    Base Subhead, baseSubhead, base_subhead = LucidaGrande-Bold, 22.0, red, red, red, #a60e0e, #ffa60e0e, 166, 14, 14, 1.00
+        We can also access optional stuff without an IF, which will result in an empty string like so: 
+    Body, body, body = LucidaGrande, 14.0, blue, blue, blue, #0e28a6, #ff0e28a6, 14, 40, 166, 1.00
+        We can also access optional stuff without an IF, which will result in an empty string like so: 
+    line height is 24.0, Body 2, body2, body_2 = MyCustomFont-Regular, 14.0, Blue Sky, blueSky, blue_sky, letter spacing is: 1.5, #62b6df, #ff62b6df, 98, 182, 223, 1.00, alignment is right
+        This is an attempt of an indented multi-line
+        block containing a text alignment, which is right
+        and also capable of inlining another condition
+        like getting the ARGB value #ff62b6df, right?
+        We can also access optional stuff without an IF, which will result in an empty string like so: right
+    Highlight, highlight, highlight = AppleGothic, 18.0, purple, purple, purple, #a30ea6, #ffa30ea6, 163, 14, 166, 1.00
+        We can also access optional stuff without an IF, which will result in an empty string like so: 
+    line height is 24.0, Large Heading, largeHeading, large_heading = MyCustomFont-Light, 32.0, Clear Reddish, clearReddish, clear_reddish, #df6369, #ccdf6369, 223, 99, 105, 0.80, alignment is left
+        This is an attempt of an indented multi-line
+        block containing a text alignment, which is left
+        and also capable of inlining another condition
+        like getting the ARGB value #ccdf6369, right?
+        We can also access optional stuff without an IF, which will result in an empty string like so: left
 }


### PR DESCRIPTION
This PR adds some new abilities: 

* Support `{{% IF token %}}...{{% ENDIF %}}` conditional syntax, for optional content such as text style alignment, line height, etc. 

* Generalize the way Prism detects blocks (e.g. `FOR` or `IF`) in templates

* Support inline blocks like mentioned above, and not just those where the start and end are at separate lines