### PR TITLE
Support isFirst/isLast tokens and inverted conditionals

### DIFF
--- a/Documentation/Tokens.md
+++ b/Documentation/Tokens.md
@@ -10,8 +10,17 @@ Tokens live inside your ***.prism** templates and follow the format `{{%TOKEN%}}
 |------------------|--------------------------------------------------------------------------------------------------|
 | `FOR collection` | Iterate over asset collections, for example `FOR textStyle`, `FOR color`, or `FOR spacing`       |
 | `END collection` | End iterating over asset collections, for example `END textStyle`, `END color`, or `END spacing` |
-| `IF token`       | Confirm a token is available, for example `IF textStyle.alignment`                               |
+| `IF token`       | Confirm a token is available, for example `IF textStyle.alignment`. Conditions can also be inverted if they are prefixed by `!`, for example `IF !textStyle.alignment` |
 | `ENDIF`          | Closes an `IF` block                                                                             |
+
+## Loop Tokens
+
+These tokens specifically work in the scope of a loop (e.g. `FOR textStyle`)
+
+| Token            | Description                                                                                          |
+|------------------|------------------------------------------------------------------------------------------------------|
+| `isFirst`        | Determine whether or not the current item is the first in a loop (e.g. `{{% IF color.isFirst %}}`    |
+| `isLast`         | Determine whether or not the current item is the last in a loop (e.g. `{{% IF textStyle.isLast %}}`  |
 
 ## Color Tokens
 

--- a/Examples/JSON/colors.json.prism
+++ b/Examples/JSON/colors.json.prism
@@ -1,0 +1,17 @@
+[
+    {{% FOR color %}}
+    {
+        "identity": {
+            "raw": "{{% color.identity %}}",
+            "camelcase": "{{% color.identity.camelcase %}}",
+            "snakecase": "{{% color.identity.snakecase %}}"
+        },
+        "r": {{% color.r %}},
+        "g": {{% color.g %}},
+        "b": {{% color.b %}},
+        "a": {{% color.a %}},
+        "rgb": "{{% color.rgb %}}",
+        "argb": "{{% color.argb %}}"
+    }{{% IF !color.isLast %}},{{% ENDIF %}}
+    {{% END color %}}
+]

--- a/Examples/JSON/spacing.json.prism
+++ b/Examples/JSON/spacing.json.prism
@@ -1,0 +1,5 @@
+{
+    {{% FOR spacing %}}
+    "{{% spacing.identity %}}": {{% spacing.value %}}{{% IF !spacing.isLast %}},{{% ENDIF %}}
+    {{% END spacing %}}
+}

--- a/Examples/JSON/textStyles.json.prism
+++ b/Examples/JSON/textStyles.json.prism
@@ -1,0 +1,32 @@
+[
+    {{% FOR textStyle %}}
+    {
+        "identity": {
+            "raw": "{{% textStyle.identity %}}",
+            "camelcase": "{{% textStyle.identity.camelcase %}}",
+            "snakecase": "{{% textStyle.identity.snakecase %}}"
+        },
+        "fontName": "{{% textStyle.fontName %}}",
+        "font": "{{% textStyle.font %}}",
+        {{% IF textStyle.alignment %}}"alignment": textStyle.alignment,{{% ENDIF %}}
+        {{% IF textStyle.lineHeight %}}"lineHeight": textStyle.lineHeight,{{% ENDIF %}}
+        {{% IF textStyle.letterSpacing %}}"letterSpacing": textStyle.letterSpacing,{{% ENDIF %}}
+        {{% IF textStyle.color %}}
+        "color": {
+            "identity": {
+                "raw": "{{% textStyle.color.identity %}}",
+                "camelcase": "{{% textStyle.color.identity.camelcase %}}",
+                "snakecase": "{{% textStyle.color.identity.snakecase %}}"
+            },
+            "r": {{% textStyle.color.r %}},
+            "g": {{% textStyle.color.g %}},
+            "b": {{% textStyle.color.b %}},
+            "a": {{% textStyle.color.a %}},
+            "rgb": "{{% textStyle.color.rgb %}}",
+            "argb": "{{% textStyle.color.argb %}}"
+        },
+        {{% ENDIF %}}
+        "fontSize": {{% textStyle.fontSize %}}
+    }{{% IF !textStyle.isLast %}},{{% ENDIF %}}
+    {{% END textStyle %}}
+]

--- a/Sources/PrismCore/TemplateParser/TemplateParser+Token.swift
+++ b/Sources/PrismCore/TemplateParser/TemplateParser+Token.swift
@@ -55,7 +55,7 @@ extension TemplateParser {
             }
             
             let colorToken = String(cleanToken.dropFirst(6))
-            
+
             switch colorToken {
             case "r":
                 self = .colorRed(color.r)
@@ -165,6 +165,35 @@ extension TemplateParser {
                 self = .spacingValue(spacing.value)
             default:
                 throw Error.unknownToken(token: rawSpacingToken)
+            }
+        }
+
+        /// Determine if a provided token is a valid loop position token
+        /// e.g. "isFirst", "isLast" based on the provided `LoopPosition`
+        ///
+        /// - parameter token: Raw string token
+        /// - parameter position: Loop position object
+        /// - parameter base: Base asset, e.g. "color", "textStyle", "spacing"
+        ///
+        /// - returns: A tuple where the first boolean indicates this is a valid position token,
+        ///            and the second indicates it correctly matches the provided block position
+        static func isValidPositionToken(_ token: String,
+                                         for position: Block.LoopPosition,
+                                         base: String) -> (isValid: Bool, doesMatch: Bool) {
+            let pieces = token.lowercased().components(separatedBy: ".")
+            guard pieces.count == 2,
+                  pieces[0] == base.lowercased() else { return (false, false) }
+
+            let rawPosition = pieces[1]
+            let isValid = rawPosition == "isfirst" || rawPosition == "islast"
+
+            switch (rawPosition, position) {
+            case ("isfirst", .first), ("isfirst", .single):
+                return (isValid, true)
+            case ("islast", .last), ("islast", .single):
+                return (isValid, true)
+            default:
+                return (isValid, false)
             }
         }
 

--- a/Sources/PrismCore/TemplateParser/TemplateParser.swift
+++ b/Sources/PrismCore/TemplateParser/TemplateParser.swift
@@ -149,10 +149,10 @@ public class TemplateParser {
                                                  .enumerated()
                                                  .reduce(into: [String]()) { result, spacingAndIndex in
                         let (index, spacing) = spacingAndIndex
-                                                    result.append(contentsOf: try recursivelyParse(lines: forBlock.body,
-                                                                                                   spacing: spacing,
-                                                                                                   loopPosition: position(for: index,
-                                                                                                                          totalItems: numberOfSpacings)))
+                        result.append(contentsOf: try recursivelyParse(lines: forBlock.body,
+                                                                       spacing: spacing,
+                                                                       loopPosition: position(for: index,
+                                                                                              totalItems: numberOfSpacings)))
                     }
 
                     output.append(contentsOf: spacingLoop)
@@ -216,6 +216,11 @@ public class TemplateParser {
                         guard positionToken.isValid else { throw error }
                         tokenHasValue = positionToken.doesMatch
                     }
+                } else if spacing != nil {
+                    let positionToken = Token.isValidPositionToken(condition.identifier,
+                                                                   for: loopPosition,
+                                                                   base: "spacing")
+                    tokenHasValue = positionToken.doesMatch
                 } else {
                     throw Error.unknownToken(token: condition.identifier)
                 }
@@ -237,12 +242,14 @@ public class TemplateParser {
                         output.append(contentsOf: try recursivelyParse(lines: [final],
                                                                        color: color,
                                                                        textStyle: textStyle,
+                                                                       spacing: spacing,
                                                                        loopPosition: loopPosition))
                     }
                 } else if tokenHasValue {
                     output.append(contentsOf: try recursivelyParse(lines: condition.body,
                                                                    color: color,
                                                                    textStyle: textStyle,
+                                                                   spacing: spacing,
                                                                    loopPosition: loopPosition))
                 }
 

--- a/Sources/PrismCore/TemplateParser/TemplateParser.swift
+++ b/Sources/PrismCore/TemplateParser/TemplateParser.swift
@@ -219,6 +219,11 @@ public class TemplateParser {
                 } else {
                     throw Error.unknownToken(token: condition.identifier)
                 }
+
+                // Flip the conditional if the block is inverted (e.g. has a `!` prefix)
+                if condition.isInverted {
+                    tokenHasValue.toggle()
+                }
                 
                 if let preBody = condition.preBody,
                    let postBody = condition.postBody {

--- a/Tests/TemplateParserSpec.swift
+++ b/Tests/TemplateParserSpec.swift
@@ -84,13 +84,18 @@ class TemplateParserSpec: QuickSpec {
                 Some Structure {
                     {{% FOR textStyle %}}
                     {{% IF textStyle.isFirst %}}This is the first text style{{% ENDIF %}}
+                    {{% IF !textStyle.isFirst %}}This is NOT the first text style{{% ENDIF %}}
                     {{% IF textStyle.isLast %}}This is the last text style{{% ENDIF %}}
+                    {{% IF !textStyle.isLast %}}This is NOT the last text style{{% ENDIF %}}
                     {{% IF textStyle.lineHeight %}}line height is {{%textStyle.lineHeight%}}, {{% ENDIF %}}{{%textStyle.identity%}}, {{%textStyle.identity.camelcase%}}, {{%textStyle.identity.snakecase%}} = {{%textStyle.fontName%}}, {{%textStyle.fontSize%}}, {{%textStyle.color.identity%}}, {{%textStyle.color.identity.camelcase%}}, {{%textStyle.color.identity.snakecase%}}, {{% IF textStyle.letterSpacing %}}letter spacing is: {{%textStyle.letterSpacing%}}, {{% ENDIF %}}{{%textStyle.color.rgb%}}, {{%textStyle.color.argb%}}, {{%textStyle.color.r%}}, {{%textStyle.color.g%}}, {{%textStyle.color.b%}}, {{%textStyle.color.a%}}{{% IF textStyle.alignment %}}, alignment is {{%textStyle.alignment%}}{{% ENDIF %}}
                         {{% IF textStyle.alignment %}}
                         This is an attempt of an indented multi-line
                         block containing a text alignment, which is {{%textStyle.alignment%}}
                         and also capable of inlining another condition
                         like {{% IF textStyle.color.argb %}}getting the ARGB value {{%textStyle.color.argb%}}, right?{{% ENDIF %}}
+                        {{% ENDIF %}}
+                        {{% IF !textStyle.alignment %}}
+                        The text style {{% textStyle.identity %}} has no alignment
                         {{% ENDIF %}}
                         We can also access optional stuff without an IF, which will result in an empty string like so: {{%textStyle.alignment%}}
                     {{% END textStyle %}}

--- a/Tests/TemplateParserSpec.swift
+++ b/Tests/TemplateParserSpec.swift
@@ -87,7 +87,7 @@ class TemplateParserSpec: QuickSpec {
                     {{% IF !textStyle.isFirst %}}This is NOT the first text style{{% ENDIF %}}
                     {{% IF textStyle.isLast %}}This is the last text style{{% ENDIF %}}
                     {{% IF !textStyle.isLast %}}This is NOT the last text style{{% ENDIF %}}
-                    {{% IF textStyle.lineHeight %}}line height is {{%textStyle.lineHeight%}}, {{% ENDIF %}}{{%textStyle.identity%}}, {{%textStyle.identity.camelcase%}}, {{%textStyle.identity.snakecase%}} = {{%textStyle.fontName%}}, {{%textStyle.fontSize%}}, {{%textStyle.color.identity%}}, {{%textStyle.color.identity.camelcase%}}, {{%textStyle.color.identity.snakecase%}}, {{% IF textStyle.letterSpacing %}}letter spacing is: {{%textStyle.letterSpacing%}}, {{% ENDIF %}}{{%textStyle.color.rgb%}}, {{%textStyle.color.argb%}}, {{%textStyle.color.r%}}, {{%textStyle.color.g%}}, {{%textStyle.color.b%}}, {{%textStyle.color.a%}}{{% IF textStyle.alignment %}}, alignment is {{%textStyle.alignment%}}{{% ENDIF %}}
+                    {{% IF textStyle.lineHeight %}}line height is {{%textStyle.lineHeight%}}, {{% ENDIF %}}{{%textStyle.identity%}}, {{%textStyle.identity.camelcase%}}, {{%textStyle.identity.snakecase%}} = {{%textStyle.fontName%}}, {{%textStyle.fontSize%}}, {{%textStyle.fontWeight%}}, {{%textStyle.fontStyle%}}, {{%textStyle.fontStretch%}}, {{%textStyle.color.identity%}}, {{%textStyle.color.identity.camelcase%}}, {{%textStyle.color.identity.snakecase%}}, {{% IF textStyle.letterSpacing %}}letter spacing is: {{%textStyle.letterSpacing%}}, {{% ENDIF %}}{{%textStyle.color.rgb%}}, {{%textStyle.color.argb%}}, {{%textStyle.color.r%}}, {{%textStyle.color.g%}}, {{%textStyle.color.b%}}, {{%textStyle.color.a%}}{{% IF textStyle.alignment %}}, alignment is {{%textStyle.alignment%}}{{% ENDIF %}}
                         {{% IF textStyle.alignment %}}
                         This is an attempt of an indented multi-line
                         block containing a text alignment, which is {{%textStyle.alignment%}}
@@ -171,7 +171,7 @@ class TemplateParserSpec: QuickSpec {
 
                 Some SpacingSructure {
                     {{% FOR spacing %}}
-                    {{%spacing.identity%}}, {{% spacing.identity.camelcase %}}, {{%spacing.identity.snakecase%}} = {{% spacing.value %}}
+                    {{%spacing.identity%}}, {{% spacing.identity.camelcase %}}, {{%spacing.identity.snakecase%}} = {{% spacing.value %}}{{% IF !spacing.isLast %}},{{% ENDIF %}}
                     {{% END spacing %}}
                 }
                 """

--- a/Tests/TemplateParserSpec.swift
+++ b/Tests/TemplateParserSpec.swift
@@ -29,7 +29,7 @@ class TemplateParserSpec: QuickSpec {
 
                 Some Structure {
                     {{% FOR color %}}
-                    {{%color.identity%}}, {{%color.identity.camelcase%}}, {{%color.identity.snakecase%}} = {{%color.r%}}, {{%color.g%}}, {{%color.b%}}, {{%color.a%}}, {{%color.argb%}}, {{%color.ARGB%}}, {{%color.rgb%}}, {{%color.RGB%}}, {{% IF color.argb %}}inline conditionally getting the ARGB value {{%color.argb%}}, right?{{% ENDIF %}}
+                    {{%color.identity%}}, {{% IF color.isFirst %}}This is the first color, {{% ENDIF %}}{{% IF color.isLast %}}This is the last color, {{% ENDIF %}}{{%color.identity.camelcase%}}, {{%color.identity.snakecase%}} = {{%color.r%}}, {{%color.g%}}, {{%color.b%}}, {{%color.a%}}, {{%color.argb%}}, {{%color.ARGB%}}, {{%color.rgb%}}, {{%color.RGB%}}, {{% IF color.argb %}}inline conditionally getting the ARGB value {{%color.argb%}}, right?{{% ENDIF %}}
                     {{% END color %}}
                 }
                 """
@@ -37,6 +37,35 @@ class TemplateParserSpec: QuickSpec {
                 assertSnapshot(matching: try! parser.parse(template: template),
                                as: .lines,
                                named: "Color Loop should provide valid output")
+            }
+        }
+
+        describe("Single Color Loop") {
+            it("should match both isFirst and isLast") {
+                let projectResult = Prism(jwtToken: "fake").mock(type: .successful)
+                let project = ProjectAssets(id: "12345",
+                                            colors: [try! projectResult.get().colors.first!],
+                                            textStyles: [],
+                                            spacing: [])
+                let parser = TemplateParser(project: project)
+
+                let template = """
+                /// This file was generated using Prism
+
+                fake line 1
+                fake line 2
+
+                Some Structure {
+                    {{% FOR color %}}
+                    {{% IF color.isFirst %}}This is the first color{{% ENDIF %}}
+                    {{% IF color.isLast %}}This is the last color{{% ENDIF %}}
+                    {{% END color %}}
+                }
+                """
+
+                assertSnapshot(matching: try! parser.parse(template: template),
+                               as: .lines,
+                               named: "Single Color Loop should match both isFirst and isLast")
             }
         }
 
@@ -54,7 +83,9 @@ class TemplateParserSpec: QuickSpec {
 
                 Some Structure {
                     {{% FOR textStyle %}}
-                    {{% IF textStyle.lineHeight %}}line height is {{%textStyle.lineHeight%}}, {{% ENDIF %}}{{%textStyle.identity%}}, {{%textStyle.identity.camelcase%}}, {{%textStyle.identity.snakecase%}} = {{%textStyle.fontName%}}, {{%textStyle.fontSize%}}, {{%textStyle.fontWeight%}}, {{%textStyle.fontStyle%}}, {{%textStyle.fontStretch%}}, {{%textStyle.color.identity%}}, {{%textStyle.color.identity.camelcase%}}, {{%textStyle.color.identity.snakecase%}}, {{% IF textStyle.letterSpacing %}}letter spacing is: {{%textStyle.letterSpacing%}}, {{% ENDIF %}}{{%textStyle.color.rgb%}}, {{%textStyle.color.argb%}}, {{%textStyle.color.r%}}, {{%textStyle.color.g%}}, {{%textStyle.color.b%}}, {{%textStyle.color.a%}}{{% IF textStyle.alignment %}}, alignment is {{%textStyle.alignment%}}{{% ENDIF %}}
+                    {{% IF textStyle.isFirst %}}This is the first text style{{% ENDIF %}}
+                    {{% IF textStyle.isLast %}}This is the last text style{{% ENDIF %}}
+                    {{% IF textStyle.lineHeight %}}line height is {{%textStyle.lineHeight%}}, {{% ENDIF %}}{{%textStyle.identity%}}, {{%textStyle.identity.camelcase%}}, {{%textStyle.identity.snakecase%}} = {{%textStyle.fontName%}}, {{%textStyle.fontSize%}}, {{%textStyle.color.identity%}}, {{%textStyle.color.identity.camelcase%}}, {{%textStyle.color.identity.snakecase%}}, {{% IF textStyle.letterSpacing %}}letter spacing is: {{%textStyle.letterSpacing%}}, {{% ENDIF %}}{{%textStyle.color.rgb%}}, {{%textStyle.color.argb%}}, {{%textStyle.color.r%}}, {{%textStyle.color.g%}}, {{%textStyle.color.b%}}, {{%textStyle.color.a%}}{{% IF textStyle.alignment %}}, alignment is {{%textStyle.alignment%}}{{% ENDIF %}}
                         {{% IF textStyle.alignment %}}
                         This is an attempt of an indented multi-line
                         block containing a text alignment, which is {{%textStyle.alignment%}}

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Color-Loop-should-provide-valid-output.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Color-Loop-should-provide-valid-output.txt
@@ -4,12 +4,12 @@ fake line 1
 fake line 2
 
 Some Structure {
-    Blue Sky, blueSky, blue_sky = 98, 182, 223, 1.00, #ff62b6df, #ff62b6df, #62b6df, #62b6df, inline conditionally getting the ARGB value #ff62b6df, right?
+    Blue Sky, This is the first color, blueSky, blue_sky = 98, 182, 223, 1.00, #ff62b6df, #ff62b6df, #62b6df, #62b6df, inline conditionally getting the ARGB value #ff62b6df, right?
     Clear Reddish, clearReddish, clear_reddish = 223, 99, 105, 0.80, #ccdf6369, #ccdf6369, #df6369, #df6369, inline conditionally getting the ARGB value #ccdf6369, right?
     blue, blue, blue = 14, 40, 166, 1.00, #ff0e28a6, #ff0e28a6, #0e28a6, #0e28a6, inline conditionally getting the ARGB value #ff0e28a6, right?
     green, green, green = 98, 166, 14, 1.00, #ff62a60e, #ff62a60e, #62a60e, #62a60e, inline conditionally getting the ARGB value #ff62a60e, right?
     mud, mud, mud = 166, 137, 14, 1.00, #ffa6890e, #ffa6890e, #a6890e, #a6890e, inline conditionally getting the ARGB value #ffa6890e, right?
     purple, purple, purple = 163, 14, 166, 1.00, #ffa30ea6, #ffa30ea6, #a30ea6, #a30ea6, inline conditionally getting the ARGB value #ffa30ea6, right?
     red, red, red = 166, 14, 14, 1.00, #ffa60e0e, #ffa60e0e, #a60e0e, #a60e0e, inline conditionally getting the ARGB value #ffa60e0e, right?
-    teal, teal, teal = 14, 126, 166, 1.00, #ff0e7ea6, #ff0e7ea6, #0e7ea6, #0e7ea6, inline conditionally getting the ARGB value #ff0e7ea6, right?
+    teal, This is the last color, teal, teal = 14, 126, 166, 1.00, #ff0e7ea6, #ff0e7ea6, #0e7ea6, #0e7ea6, inline conditionally getting the ARGB value #ff0e7ea6, right?
 }

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Single-Color-Loop-should-match-both-isFirst-and-isLast.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Single-Color-Loop-should-match-both-isFirst-and-isLast.txt
@@ -1,0 +1,9 @@
+/// This file was generated using Prism
+
+fake line 1
+fake line 2
+
+Some Structure {
+    This is the first color
+    This is the last color
+}

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Spacing-Loop-should-provide-valid-output.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Spacing-Loop-should-provide-valid-output.txt
@@ -4,11 +4,11 @@ fake line 1
 fake line 2
 
 Some SpacingSructure {
-    spacing-xxs, spacingXXS, spacing_xxs = 4
-    spacing-xs, spacingXS, spacing_xs = 8
-    spacing-s, spacingS, spacing_s = 12
-    spacing-m, spacingM, spacing_m = 16
-    spacing-l, spacingL, spacing_l = 24
-    spacing-xl, spacingXL, spacing_xl = 32
+    spacing-xxs, spacingXXS, spacing_xxs = 4,
+    spacing-xs, spacingXS, spacing_xs = 8,
+    spacing-s, spacingS, spacing_s = 12,
+    spacing-m, spacingM, spacing_m = 16,
+    spacing-l, spacingL, spacing_l = 24,
+    spacing-xl, spacingXL, spacing_xl = 32,
     spacing-xxl, spacingXXL, spacing_xxl = 40.2
 }

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
@@ -6,22 +6,22 @@ fake line 2
 Some Structure {
     This is the first text style
     This is NOT the last text style
-    line height is 26, Base Heading, baseHeading, base_heading = LucidaGrande-Bold, 26.0, green, green, green, letter spacing is: 0.4, #62a60e, #ff62a60e, 98, 166, 14, 1.00
+    line height is 26, Base Heading, baseHeading, base_heading = LucidaGrande-Bold, 26.0, 700, normal, 1.0, green, green, green, letter spacing is: 0.4, #62a60e, #ff62a60e, 98, 166, 14, 1.00
         The text style Base Heading has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
     This is NOT the first text style
     This is NOT the last text style
-    line height is 22.53, Base Subhead, baseSubhead, base_subhead = LucidaGrande-Bold, 22.0, red, red, red, letter spacing is: 0.49, #a60e0e, #ffa60e0e, 166, 14, 14, 1.00
+    line height is 22.53, Base Subhead, baseSubhead, base_subhead = LucidaGrande-Bold, 22.0, 700, normal, 1.0, red, red, red, letter spacing is: 0.49, #a60e0e, #ffa60e0e, 166, 14, 14, 1.00
         The text style Base Subhead has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
     This is NOT the first text style
     This is NOT the last text style
-    Body, body, body = LucidaGrande, 14.0, blue, blue, blue, letter spacing is: 0.5, #0e28a6, #ff0e28a6, 14, 40, 166, 1.00
+    Body, body, body = LucidaGrande, 14.0, 400, normal, 1.0, blue, blue, blue, letter spacing is: 0.5, #0e28a6, #ff0e28a6, 14, 40, 166, 1.00
         The text style Body has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
     This is NOT the first text style
     This is NOT the last text style
-    line height is 24, Body 2, body2, body_2 = MyCustomFont-Regular, 14.0, Blue Sky, blueSky, blue_sky, letter spacing is: 1.5, #62b6df, #ff62b6df, 98, 182, 223, 1.00, alignment is right
+    line height is 24, Body 2, body2, body_2 = MyCustomFont-Regular, 14.0, 700, normal, 1.0, Blue Sky, blueSky, blue_sky, letter spacing is: 1.5, #62b6df, #ff62b6df, 98, 182, 223, 1.00, alignment is right
         This is an attempt of an indented multi-line
         block containing a text alignment, which is right
         and also capable of inlining another condition
@@ -29,12 +29,12 @@ Some Structure {
         We can also access optional stuff without an IF, which will result in an empty string like so: right
     This is NOT the first text style
     This is NOT the last text style
-    Highlight, highlight, highlight = AppleGothic, 18.0, purple, purple, purple, #a30ea6, #ffa30ea6, 163, 14, 166, 1.00
+    Highlight, highlight, highlight = AppleGothic, 18.0, 400, normal, 1.0, purple, purple, purple, #a30ea6, #ffa30ea6, 163, 14, 166, 1.00
         The text style Highlight has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
     This is NOT the first text style
     This is the last text style
-    line height is 24, Large Heading, largeHeading, large_heading = MyCustomFont-Light, 32.0, Clear Reddish, clearReddish, clear_reddish, #df6369, #ccdf6369, 223, 99, 105, 0.80, alignment is left
+    line height is 24, Large Heading, largeHeading, large_heading = MyCustomFont-Light, 32.0, 700, normal, 1.0, Clear Reddish, clearReddish, clear_reddish, #df6369, #ccdf6369, 223, 99, 105, 0.80, alignment is left
         This is an attempt of an indented multi-line
         block containing a text alignment, which is left
         and also capable of inlining another condition

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
@@ -4,7 +4,8 @@ fake line 1
 fake line 2
 
 Some Structure {
-    line height is 26, Base Heading, baseHeading, base_heading = LucidaGrande-Bold, 26.0, 700, normal, 1.0, green, green, green, letter spacing is: 0.4, #62a60e, #ff62a60e, 98, 166, 14, 1.00
+    This is the first text style
+    line height is 26, Base Heading, baseHeading, base_heading = LucidaGrande-Bold, 26.0, green, green, green, letter spacing is: 0.4, #62a60e, #ff62a60e, 98, 166, 14, 1.00
         We can also access optional stuff without an IF, which will result in an empty string like so: 
     line height is 22.53, Base Subhead, baseSubhead, base_subhead = LucidaGrande-Bold, 22.0, 700, normal, 1.0, red, red, red, letter spacing is: 0.49, #a60e0e, #ffa60e0e, 166, 14, 14, 1.00
         We can also access optional stuff without an IF, which will result in an empty string like so: 
@@ -18,7 +19,8 @@ Some Structure {
         We can also access optional stuff without an IF, which will result in an empty string like so: right
     Highlight, highlight, highlight = AppleGothic, 18.0, 400, normal, 1.0, purple, purple, purple, #a30ea6, #ffa30ea6, 163, 14, 166, 1.00
         We can also access optional stuff without an IF, which will result in an empty string like so: 
-    line height is 24, Large Heading, largeHeading, large_heading = MyCustomFont-Light, 32.0, 700, normal, 1.0, Clear Reddish, clearReddish, clear_reddish, #df6369, #ccdf6369, 223, 99, 105, 0.80, alignment is left
+    This is the last text style
+    line height is 24, Large Heading, largeHeading, large_heading = MyCustomFont-Light, 32.0, Clear Reddish, clearReddish, clear_reddish, #df6369, #ccdf6369, 223, 99, 105, 0.80, alignment is left
         This is an attempt of an indented multi-line
         block containing a text alignment, which is left
         and also capable of inlining another condition

--- a/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
+++ b/Tests/__Snapshots__/TemplateParserSpec/spec.Text-Styles-Loop-should-provide-valid-output.txt
@@ -5,20 +5,34 @@ fake line 2
 
 Some Structure {
     This is the first text style
+    This is NOT the last text style
     line height is 26, Base Heading, baseHeading, base_heading = LucidaGrande-Bold, 26.0, green, green, green, letter spacing is: 0.4, #62a60e, #ff62a60e, 98, 166, 14, 1.00
+        The text style Base Heading has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
-    line height is 22.53, Base Subhead, baseSubhead, base_subhead = LucidaGrande-Bold, 22.0, 700, normal, 1.0, red, red, red, letter spacing is: 0.49, #a60e0e, #ffa60e0e, 166, 14, 14, 1.00
+    This is NOT the first text style
+    This is NOT the last text style
+    line height is 22.53, Base Subhead, baseSubhead, base_subhead = LucidaGrande-Bold, 22.0, red, red, red, letter spacing is: 0.49, #a60e0e, #ffa60e0e, 166, 14, 14, 1.00
+        The text style Base Subhead has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
-    Body, body, body = LucidaGrande, 14.0, 400, normal, 1.0, blue, blue, blue, letter spacing is: 0.5, #0e28a6, #ff0e28a6, 14, 40, 166, 1.00
+    This is NOT the first text style
+    This is NOT the last text style
+    Body, body, body = LucidaGrande, 14.0, blue, blue, blue, letter spacing is: 0.5, #0e28a6, #ff0e28a6, 14, 40, 166, 1.00
+        The text style Body has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
-    line height is 24, Body 2, body2, body_2 = MyCustomFont-Regular, 14.0, 700, normal, 1.0, Blue Sky, blueSky, blue_sky, letter spacing is: 1.5, #62b6df, #ff62b6df, 98, 182, 223, 1.00, alignment is right
+    This is NOT the first text style
+    This is NOT the last text style
+    line height is 24, Body 2, body2, body_2 = MyCustomFont-Regular, 14.0, Blue Sky, blueSky, blue_sky, letter spacing is: 1.5, #62b6df, #ff62b6df, 98, 182, 223, 1.00, alignment is right
         This is an attempt of an indented multi-line
         block containing a text alignment, which is right
         and also capable of inlining another condition
         like getting the ARGB value #ff62b6df, right?
         We can also access optional stuff without an IF, which will result in an empty string like so: right
-    Highlight, highlight, highlight = AppleGothic, 18.0, 400, normal, 1.0, purple, purple, purple, #a30ea6, #ffa30ea6, 163, 14, 166, 1.00
+    This is NOT the first text style
+    This is NOT the last text style
+    Highlight, highlight, highlight = AppleGothic, 18.0, purple, purple, purple, #a30ea6, #ffa30ea6, 163, 14, 166, 1.00
+        The text style Highlight has no alignment
         We can also access optional stuff without an IF, which will result in an empty string like so: 
+    This is NOT the first text style
     This is the last text style
     line height is 24, Large Heading, largeHeading, large_heading = MyCustomFont-Light, 32.0, Clear Reddish, clearReddish, clear_reddish, #df6369, #ccdf6369, 223, 99, 105, 0.80, alignment is left
         This is an attempt of an indented multi-line


### PR DESCRIPTION
This PR adds/fixes a bunch of things:

- New `isFirst` / `isLast` tokens when within a loop (Resolves #27)
- Allow flipping/inverting a conditional, for example: `{{% IF !textStyle.isLast %}}` or `{{% IF !textStyle.alignment %}}`
- Better handling of multiple in-line conditions (e.g. multiple `{{% IF x %}}` in one line)
- Add JSON examples
- Fixes some issues with the new spacing features introduced in #17