### PR TITLE
Fix missing closing bracket

### DIFF
--- a/Examples/iOS/UIKit/Colors.swift.prism
+++ b/Examples/iOS/UIKit/Colors.swift.prism
@@ -6,7 +6,7 @@ public extension UIColor {
     static let {{% color.identity.camelcase %}} = UIColor(r: {{% color.r %}},
                                                           g: {{% color.g %}},
                                                           b: {{% color.b %}},
-                                                          alpha: {{% color.a %}}
+                                                          alpha: {{% color.a %}})
     {{% END color %}}
 }
 


### PR DESCRIPTION
Colors.swift.prism had a missing bracket which would not let it the code compile when generating.